### PR TITLE
make `pathos` optional. breaking change due to packaging.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,12 +15,6 @@ jobs:
               with:
                   fetch-depth: 0 # Includes getting tags
 
-            - name: Cache $HOME/.local # Significantly speeds up Poetry Install
-              uses: actions/cache@v4
-              with:
-                  path: ~/.local
-                  key: dotlocal-${{ runner.os }}-${{ hashFiles('.github/workflows/deploy.yml') }}
-
             - name: Set up python 3.11
               uses: actions/setup-python@v5
               with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,14 @@ jobs:
         run: |
           pre-commit run --all-files
 
-      - name: Test with pytest
+      - name: Test without pathos
         run: |
-          python -m pytest
+          python -m pytest -m "not requires_pathos"
+
+      - name: Install pathos
+        run: |
+          pip install -e ".[multiprocessing]"
+
+      - name: Test with pathos
+        run: |
+          python -m pytest -m "requires_pathos"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install -r requirements_dev.txt
+          pip install pre-commit
+
+      - name: Run pre-commit
+        run: |
+          pre-commit run --all-files
+
+      - name: Test with pytest
+        run: |
+          python -m pytest

--- a/lox/lock/light_switch.py
+++ b/lox/lock/light_switch.py
@@ -11,7 +11,13 @@ See https://w3.cs.jmu.edu/kirkpams/OpenCSF/Books/cs361/html/DesignAdv.html
 import threading
 from time import time
 
-import pathos.multiprocessing as mp
+try:
+    import pathos.multiprocessing as mp
+
+    _PATHOS_AVAILABLE = True
+except ImportError:
+    mp = None
+    _PATHOS_AVAILABLE = False
 
 __all__ = [
     "LightSwitch",
@@ -39,6 +45,11 @@ class LightSwitch:
         """
 
         if multiprocessing:
+            if not _PATHOS_AVAILABLE:
+                raise RuntimeError(
+                    "pathos is not installed. "
+                    "Install the full package with: pip install lox[multiprocessing]"
+                )
             self._library = mp
         else:
             self._library = threading

--- a/lox/worker/process.py
+++ b/lox/worker/process.py
@@ -31,7 +31,13 @@ import threading
 from collections import deque
 from typing import Callable
 
-import pathos.multiprocessing as mp
+try:
+    import pathos.multiprocessing as mp
+
+    _PATHOS_AVAILABLE = True
+except ImportError:
+    mp = None
+    _PATHOS_AVAILABLE = False
 
 from ..debug import LOX_DEBUG
 
@@ -63,6 +69,12 @@ class ScatterGatherCallable:
         return self._fn(*args, **kwargs)
 
     def scatter(self, *args, **kwargs):
+        if not _PATHOS_AVAILABLE:
+            raise ValueError(
+                "pathos is not installed. "
+                "Install the full package with: pip install lox[multiprocessing]"
+            )
+
         if self._instance is not None:
             args = (self._instance,) + args
 
@@ -86,6 +98,12 @@ class ScatterGatherCallable:
         return fut
 
     def gather(self, *, tqdm=None):
+        if not _PATHOS_AVAILABLE:
+            raise ValueError(
+                "pathos is not installed. "
+                "Install the full package with: pip install lox[multiprocessing]"
+            )
+
         if tqdm is not None:
             if TQDM is None:
                 raise ModuleNotFoundError("No module named 'tqdm'")
@@ -159,11 +177,21 @@ class ScatterGatherDescriptor:
         ------
         concurrent.futures.Future
         """
+        if not _PATHOS_AVAILABLE:
+            raise ValueError(
+                "pathos is not installed. "
+                "Install the full package with: pip install lox[multiprocessing]"
+            )
 
         return self._base_callable.scatter(*args, **kwargs)
 
     def gather(self, *args, **kwargs):
         """Block and collect results from prior ``scatter`` calls."""
+        if not _PATHOS_AVAILABLE:
+            raise ValueError(
+                "pathos is not installed. "
+                "Install the full package with: pip install lox[multiprocessing]"
+            )
 
         results = self._base_callable.gather(*args, **kwargs)
         self._executor = None

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 addopts = --strict-markers
 markers =
     visual
+    requires_pathos: tests that require pathos (multiprocessing) dependency

--- a/setup.py
+++ b/setup.py
@@ -17,17 +17,6 @@ readme = readme.replace(
 with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
-
-setup_requirements = [
-    "pytest-runner",
-]
-
-test_requirements = [
-    "pytest",
-]
-
 setup(
     author="Brian Pugh",
     author_email="bnp117@gmail.com",
@@ -44,7 +33,10 @@ setup(
         "Programming Language :: Python :: 3.12",
     ],
     description="Threading and Multiprocessing for every project.",
-    install_requires=requirements,
+    install_requires=[],
+    extras_require={
+        "multiprocessing": ["pathos"],
+    },
     license="MIT license",
     long_description=readme + "\n\n" + history,
     long_description_content_type="text/x-rst",
@@ -52,9 +44,7 @@ setup(
     keywords="lox",
     name="lox",
     packages=find_packages(include=["lox"]),
-    setup_requires=setup_requirements,
     test_suite="tests",
-    tests_require=test_requirements,
     url="https://github.com/BrianPugh/lox",
     version=version,
     zip_safe=False,

--- a/tests/worker/test_process.py
+++ b/tests/worker/test_process.py
@@ -9,6 +9,7 @@ SLEEP_TIME = 0.01
 N_WORKERS = 2
 
 
+@pytest.mark.requires_pathos
 def test_basic_args():
     in_x = [
         1,
@@ -61,6 +62,7 @@ def test_basic_args():
             assert (x * y) == r
 
 
+@pytest.mark.requires_pathos
 def test_basic_noargs():
     in_x = [
         1,
@@ -128,6 +130,7 @@ class Class1:
         return x * y + self.z
 
 
+@pytest.mark.requires_pathos
 def test_method_1():
     in_x = [
         1,
@@ -187,6 +190,7 @@ def mock_tqdm(mocker):
     return mocker.patch("lox.worker.process.TQDM")
 
 
+@pytest.mark.requires_pathos
 def test_tqdm_bool(mock_tqdm):
 
     in_x = [
@@ -235,6 +239,7 @@ def test_tqdm_bool(mock_tqdm):
         assert (x * y) == r
 
 
+@pytest.mark.requires_pathos
 def test_tqdm_tqdm(mocker):
     in_x = [
         1,
@@ -287,6 +292,7 @@ def test_tqdm_tqdm(mocker):
 
 
 @pytest.mark.visual
+@pytest.mark.requires_pathos
 def test_tqdm_bool_visual():
     """Primarily for visually asserting our tqdm mocks are correct."""
 

--- a/tests/worker/test_process.py
+++ b/tests/worker/test_process.py
@@ -2,7 +2,6 @@ from random import random
 from time import sleep, time
 
 import pytest
-from tqdm import tqdm
 
 import lox
 

--- a/tests/worker/test_thread.py
+++ b/tests/worker/test_thread.py
@@ -4,7 +4,6 @@ from random import random
 from time import sleep, time
 
 import pytest
-from tqdm import tqdm
 
 import lox
 


### PR DESCRIPTION
`pathos` is a heavy dependency, and not necessary if people are primarily using `lox` for it's `thread` features.